### PR TITLE
feat(votes):  implement upvote and downvote

### DIFF
--- a/src/controllers/questionController.js
+++ b/src/controllers/questionController.js
@@ -1,13 +1,14 @@
 import mongoose from 'mongoose';
 import dbServices from '../services/dbServices';
 import Question from '../models/Question';
+import Vote from '../models/Vote';
 import {
   handleServerError, handleServerResponse
 } from '../utils/response';
 import { calculateLimitAndOffset, paginate } from '../utils/pagination';
 
 const {
-  create, getById, getAll, countAllRecord
+  create, getById, getAll, countAllRecord, update
 } = dbServices;
 
 mongoose.Promise = global.Promise;
@@ -69,6 +70,24 @@ const questionController = {
         .skip(offset);
       const meta = paginate(page, perPage, questionCount, questions);
       return handleServerResponse(res, 200, { questions, meta });
+    } catch (error) {
+      return handleServerError(res, error);
+    }
+  },
+  async upvoteQuestion(req, res) {
+    const { decoded: { id }, params: { questionId } } = req;
+    try {
+      const vote = await update(Vote, { owner: id, question: questionId }, { vote: 'upvote' }, { new: true, upsert: true });
+      return handleServerResponse(res, 200, { vote });
+    } catch (error) {
+      return handleServerError(res, error);
+    }
+  },
+  async downvoteQuestion(req, res) {
+    const { decoded: { id }, params: { questionId } } = req;
+    try {
+      const vote = await update(Vote, { owner: id, question: questionId }, { vote: 'downvote' }, { new: true, upsert: true });
+      return handleServerResponse(res, 200, { vote });
     } catch (error) {
       return handleServerError(res, error);
     }

--- a/src/models/Vote.js
+++ b/src/models/Vote.js
@@ -1,0 +1,20 @@
+/* eslint-disable func-names */
+import { Schema, model } from 'mongoose';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const voteSchema = new Schema({
+  owner: { type: Schema.Types.ObjectId, ref: 'User' },
+  question: { type: Schema.Types.ObjectId, ref: 'Question' },
+  vote: {
+    type: String,
+    enum: ['upvote', 'downvote', 'neutral'],
+    default: 'nuetral'
+  },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now }
+});
+
+const Vote = model('Vote', voteSchema);
+export default Vote;

--- a/src/routes/api/authRoute.js
+++ b/src/routes/api/authRoute.js
@@ -58,8 +58,10 @@ const authRoute = (router) => {
        *      properties:
        *        email:
        *          type: string
+       *          example: mc@gmail.com
        *        password:
        *          type: string
+       *          example: jabike_13
        */
 
   /**

--- a/src/routes/api/questionRoute.js
+++ b/src/routes/api/questionRoute.js
@@ -4,7 +4,9 @@ import { createSchema, getOneQuestionSchema, getAllQuestionsSchema } from '../..
 import { hasToken } from '../../utils/authHelpers';
 import { checkQuestionId } from '../../middlewares/questionMiddleware';
 
-const { create, getOneQuestion, getAllQuestions } = questionController;
+const {
+  create, getOneQuestion, getAllQuestions, upvoteQuestion, downvoteQuestion
+} = questionController;
 
 const questionRoute = (router) => {
   router.route('/questions')
@@ -86,6 +88,58 @@ const questionRoute = (router) => {
       */
 
     .get(validate(getOneQuestionSchema), checkQuestionId, getOneQuestion);
+
+  router.route('/questions/:questionId/upvote')
+  /**
+         * @swagger
+         * /api/v1/questions/{questionId}/upvote:
+         *   patch:
+         *     tags:
+         *       - Questions
+         *     description: upvote a question
+         *     produces:
+         *       - application/json
+         *     parameters:
+         *       - in: path
+         *         name: questionId
+         *         schema:
+         *           type: string
+         *     responses:
+         *       200:
+         *         description: Vote details
+         *       500:
+         *         description: Internal Server error
+         *     security:
+         *       - bearerAuth: []
+        */
+
+    .patch(hasToken, validate(getOneQuestionSchema), checkQuestionId, upvoteQuestion);
+
+  router.route('/questions/:questionId/downvote')
+  /**
+           * @swagger
+           * /api/v1/questions/{questionId}/downvote:
+           *   patch:
+           *     tags:
+           *       - Questions
+           *     description: downvote a question
+           *     produces:
+           *       - application/json
+           *     parameters:
+           *       - in: path
+           *         name: questionId
+           *         schema:
+           *           type: string
+           *     responses:
+           *       200:
+           *         description: Vote details
+           *       500:
+           *         description: Internal Server error
+           *     security:
+           *       - bearerAuth: []
+          */
+
+    .patch(hasToken, validate(getOneQuestionSchema), checkQuestionId, downvoteQuestion);
 };
 
 export default questionRoute;

--- a/src/services/dbServices.js
+++ b/src/services/dbServices.js
@@ -32,15 +32,17 @@ const DbServices = {
 
   /**
    * @param {object} model model /table
-   * @param {object} updateInfo columns with values to update
+   * @param {object} query conditions to query
+   * @param {object} updates conditions to query
    * @param {object} options columns with values to update
    * @returns {Promise} Promise resolved or rejected
    * @description updates one row whose details is passed to as argument in options with the
-   * values in updateInfo
+   * values in query
    */
-  update(model, updateInfo, options) {
-    return model.update(
-      updateInfo,
+  update(model, query, updates, options) {
+    return model.findOneAndUpdate(
+      query,
+      updates,
       options
     );
   },


### PR DESCRIPTION
#### What does this PR do?
- Implement upvote and downvote

#### Description of task to be completed
- add Vote model/mongoose-schema

- add controllers to upvote and downvote

- add PATCH endpoints for upvote and downvote

#### How to manually test this
- clone this repository using  `git clone git@github.com:Mcdavid95/stackoveerflow-clone.git` on your terminal or github desktop
- navigate to project directory on your teminal
- run `npm install`
- run `npm start`
- use the integrated docs by navigating to `localhost:3000/api/v1/docs` under the Answers segment to test the endpoints